### PR TITLE
Fix pitch-bend and modulators

### DIFF
--- a/soundfont-rs/src/data/hydra/modulator.rs
+++ b/soundfont-rs/src/data/hydra/modulator.rs
@@ -58,7 +58,7 @@ impl From<u8> for GeneralPalette {
 pub enum ControllerPalette {
     /// General Controller palette of controllers is selected.
     ///
-    /// The `index` field value corresponds to one of the following controller sources.  
+    /// The `index` field value corresponds to one of the following controller sources.
     /// - 0  No Controller
     /// - 2  Note-On Velocity
     /// - 3  Note-On Key Number
@@ -125,7 +125,7 @@ impl From<u8> for SourceType {
     }
 }
 
-/// 8.2  Modulator Source Enumerators  
+/// 8.2  Modulator Source Enumerators
 /// Flags telling the polarity of a modulator.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ModulatorSource {
@@ -503,7 +503,7 @@ pub mod default_modulators {
     ///
     /// Initial Pitch is not a "standard" generator (SF 2.04)
     ///
-    /// That's why this mod is an const fn and  
+    /// That's why this mod is an const fn and
     /// user has to decide the destination themself.
     pub const fn default_pitch_bend_mod(dest: GeneratorType) -> Modulator {
         Modulator {

--- a/src/core/synth/channel_pool/channel.rs
+++ b/src/core/synth/channel_pool/channel.rs
@@ -57,7 +57,7 @@ pub struct Channel {
     key_pressure: [i8; 128],
     channel_pressure: u8,
 
-    pitch_bend: i16,
+    pitch_bend: u16,
     pitch_wheel_sensitivity: u8,
 
     cc: [u8; 128],
@@ -243,11 +243,11 @@ impl Channel {
 
     //
 
-    pub fn pitch_bend(&self) -> i16 {
+    pub fn pitch_bend(&self) -> u16 {
         self.pitch_bend
     }
 
-    pub fn set_pitch_bend(&mut self, val: i16) {
+    pub fn set_pitch_bend(&mut self, val: u16) {
         self.pitch_bend = val;
     }
 

--- a/src/core/synth/internal/midi.rs
+++ b/src/core/synth/internal/midi.rs
@@ -493,7 +493,7 @@ Send a pitch bend message.
 pub fn pitch_bend(channel: &mut Channel, voices: &mut VoicePool, val: u16) {
     const MOD_PITCHWHEEL: u8 = 14;
 
-    channel.set_pitch_bend(val as i16);
+    channel.set_pitch_bend(val);
     voices.modulate_voices(&channel, false, MOD_PITCHWHEEL);
 }
 

--- a/src/core/synth/public/midi.rs
+++ b/src/core/synth/public/midi.rs
@@ -18,7 +18,7 @@ impl Synth {
     /**
     Get the pitch bend value.
      */
-    pub fn get_pitch_bend(&self, channel_id: u8) -> Result<i16, OxiError> {
+    pub fn get_pitch_bend(&self, channel_id: u8) -> Result<u16, OxiError> {
         let channel = self.channels.get(channel_id as usize)?;
 
         Ok(channel.pitch_bend())

--- a/src/core/synth/soundfont/modulator.rs
+++ b/src/core/synth/soundfont/modulator.rs
@@ -257,7 +257,7 @@ impl Mod {
             use SourceType::*;
 
             /* transform the second input value */
-            let v2 = match (self.src.ty, self.src.polarity, self.src.direction) {
+            let v2 = match (self.src2.ty, self.src2.polarity, self.src2.direction) {
                 // 0
                 (Linear, Unipolar, Positive) => v2 / range2,
                 // 1

--- a/src/synth/midi.rs
+++ b/src/synth/midi.rs
@@ -16,7 +16,7 @@ impl Synth {
     /**
     Get the pitch bend value.
      */
-    pub fn get_pitch_bend(&self, chan: u8) -> Result<i16, OxiError> {
+    pub fn get_pitch_bend(&self, chan: u8) -> Result<u16, OxiError> {
         self.core.get_pitch_bend(chan)
     }
 


### PR DESCRIPTION
Hi, there! Thanks for having published this fantastic work on crates.io!

My microtonal synthesizer project (https://github.com/Woyten/tune/tree/master/microwave) and the web app (https://woyten.github.io/microwave/) already depend on OxiSynth because it works so well.

But even the best piece of software is not free from small design flaws and bugs. If you don't mind I would help improving OxiSynth by creating further PRs, bug reports or feature requests. Would that be okay for you?

The current PR fixes two problems I discovered when using the pitch-bend function:

1. The conversion from `u16` to `i16` and to `f32` afterwards wasn't correct. I propose to use `u16` consistently because
    - That's the type `Synth` consumes and, therefore, it should also return it
    - That's close to the type that FluidLite uses
    - The signedness is already accounted for via `SourcePolarity::Bipolar`
2. The primary modulation source was used where, I believe, the secondary modulation source should have been used