### PR TITLE
Fix loading of 24-bit sample SF2

### DIFF
--- a/soundfont-rs/src/data/sample_data.rs
+++ b/soundfont-rs/src/data/sample_data.rs
@@ -35,7 +35,7 @@ impl SampleData {
                     smpl = Some(ch);
                 }
                 // [<sm24-ck>] The Digital Audio Samples for the lower 8 bits
-                "sm23" => {
+                "sm24" => {
                     sm24 = Some(ch);
                 }
                 _ => {


### PR DESCRIPTION
There was a small typo that caused an error when trying to load any 24-bit sample SF2.