### PR TITLE
Gracefully handle non spec SF2

### DIFF
--- a/soundfont-rs/src/data/hydra/generator.rs
+++ b/soundfont-rs/src/data/hydra/generator.rs
@@ -97,7 +97,9 @@ impl Generator {
             let data = pmod.read_contents(file).unwrap();
             let mut reader = Reader::new(data);
 
-            (0..amount).map(|_| Self::read(&mut reader)).collect()
+            Ok((0..amount)
+                .filter_map(|_| Self::read(&mut reader).ok())
+                .collect())
         }
     }
 }

--- a/soundfont-rs/src/data/utils.rs
+++ b/soundfont-rs/src/data/utils.rs
@@ -24,14 +24,18 @@ impl Reader {
         let end = self.curr + len;
         self.curr = end;
 
-        let mut data = self.data[start..end].to_vec();
-        // Null terminate it, just in case...
-        data.push(0x0);
+        let data = &self.data[start..end];
 
-        let name = unsafe { std::ffi::CStr::from_ptr(data.as_ptr() as _) };
+        let data = if let Some(end) = data.iter().position(|v| *v == 0) {
+            &data[..end]
+        } else {
+            &data
+        };
 
-        let name = name.to_str().map_err(ParseError::from)?;
-        let name = name.to_owned();
+        // Acording to the spec, strings have to be in ASCII.
+        // But obviously this is SF2 world, spec is just a suggestion, people use non ASCII characters.
+        // So let's just use � for those characters.
+        let name = String::from_utf8_lossy(&data).to_string();
 
         Ok(name)
     }

--- a/src/core/midi.rs
+++ b/src/core/midi.rs
@@ -375,7 +375,7 @@ pub(in super::super) fn cc(
 
                 // SontFont 2.01 NRPN Message (Sect. 9.6, p. 74)
                 if nrpn_msb == 120 && nrpn_lsb < 100 {
-                    if (nrpn_select as i32) < GeneratorType::Last as i32 {
+                    if (nrpn_select as i32) < GeneratorType::last() as i32 {
                         let scale_nrpn: f32 = gen_scale_nrpn(nrpn_select, data);
 
                         let param = FromPrimitive::from_u8(nrpn_select as u8).unwrap();

--- a/src/core/soundfont/generator.rs
+++ b/src/core/soundfont/generator.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use super::super::Channel;
 
 use num_derive::FromPrimitive;
@@ -136,19 +138,25 @@ pub enum GeneratorType {
     modulator.
     */
     Pitch = 59,
-
-    Last = 60,
 }
 
-impl From<soundfont::data::GeneratorType> for GeneratorType {
-    fn from(value: soundfont::data::GeneratorType) -> Self {
-        num_traits::FromPrimitive::from_u8(value as u8).unwrap()
+impl GeneratorType {
+    pub fn last() -> u8 {
+        60
+    }
+}
+
+impl TryFrom<soundfont::data::GeneratorType> for GeneratorType {
+    type Error = ();
+
+    fn try_from(value: soundfont::data::GeneratorType) -> Result<Self, Self::Error> {
+        num_traits::FromPrimitive::from_u8(value as u8).ok_or(())
     }
 }
 
 impl GeneratorType {
     pub fn iter() -> impl Iterator<Item = Self> {
-        (0..Self::Last as u8).map(|v| num_traits::FromPrimitive::from_u8(v).unwrap())
+        (0..Self::last()).map(|v| num_traits::FromPrimitive::from_u8(v).unwrap())
     }
 }
 

--- a/src/core/soundfont/instrument.rs
+++ b/src/core/soundfont/instrument.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom as _;
 use std::sync::Arc;
 
 use crate::GeneratorType;
@@ -100,10 +101,11 @@ impl InstrumentZone {
                     vel_high = amount.high;
                 }
                 _ => {
-                    let ty = GeneratorType::from(new_gen.ty);
-                    // FIXME: some generators have an unsigned word amount value but i don't know which ones
-                    gen[ty].val = *new_gen.amount.as_i16().unwrap() as f64;
-                    gen[ty].flags = GEN_SET as u8;
+                    if let Ok(ty) = GeneratorType::try_from(new_gen.ty) {
+                        // FIXME: some generators have an unsigned word amount value but i don't know which ones
+                        gen[ty].val = *new_gen.amount.as_i16().unwrap() as f64;
+                        gen[ty].flags = GEN_SET as u8;
+                    }
                 }
             }
         }

--- a/src/core/soundfont/preset.rs
+++ b/src/core/soundfont/preset.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom as _;
 use std::sync::Arc;
 
 use super::generator::{GeneratorList, GeneratorType};
@@ -113,11 +114,11 @@ impl PresetZone {
                     vel_high = amount.high;
                 }
                 _ => {
-                    let ty = GeneratorType::from(sfgen.ty);
-
-                    // FIXME: some generators have an unsigned word amount value but i don't know which ones
-                    gen[ty].val = *sfgen.amount.as_i16().unwrap() as f64;
-                    gen[ty].flags = GEN_SET as u8;
+                    if let Ok(ty) = GeneratorType::try_from(sfgen.ty) {
+                        // FIXME: some generators have an unsigned word amount value but i don't know which ones
+                        gen[ty].val = *sfgen.amount.as_i16().unwrap() as f64;
+                        gen[ty].flags = GEN_SET as u8;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Turns out SF2 is a wild west, let's be more lenient on enforcing the spec.
- Ignore non-spec generators
- Ignore non-ascii characters in strings

related: https://github.com/PolyMeilex/Neothesia/issues/32