### PR TITLE
soundfont-rs: Drop riff dependency

### DIFF
--- a/soundfont-rs/Cargo.toml
+++ b/soundfont-rs/Cargo.toml
@@ -9,7 +9,3 @@ keywords = ["sf2","soundfont"]
 license = "MIT"
 repository = "https://github.com/PolyMeilex/OxiSynth"
 documentation = "https://docs.rs/soundfont"
-
-
-[dependencies]
-riff = "2.0.0"

--- a/soundfont-rs/src/data/hydra/bag.rs
+++ b/soundfont-rs/src/data/hydra/bag.rs
@@ -1,7 +1,7 @@
-use crate::error::ParseError;
+use crate::{error::ParseError, riff::ChunkId};
 
 use super::super::utils::Reader;
-use riff::Chunk;
+use crate::riff::Chunk;
 use std::io::{Read, Seek};
 
 #[derive(Debug)]
@@ -22,7 +22,7 @@ impl Bag {
     }
 
     pub fn read_all<F: Read + Seek>(pbag: &Chunk, file: &mut F) -> Result<Vec<Self>, ParseError> {
-        assert!(pbag.id().as_str() == "pbag" || pbag.id().as_str() == "ibag");
+        assert!(pbag.id() == ChunkId::pbag || pbag.id() == ChunkId::ibag);
 
         let size = pbag.len();
         if size % 4 != 0 || size == 0 {

--- a/soundfont-rs/src/data/hydra/generator.rs
+++ b/soundfont-rs/src/data/hydra/generator.rs
@@ -1,6 +1,6 @@
 use super::super::utils::Reader;
 use crate::error::ParseError;
-use riff::Chunk;
+use crate::riff::{Chunk, ChunkId};
 use std::convert::{TryFrom, TryInto};
 use std::io::{Read, Seek};
 
@@ -86,7 +86,7 @@ impl Generator {
     }
 
     pub fn read_all<F: Read + Seek>(pmod: &Chunk, file: &mut F) -> Result<Vec<Self>, ParseError> {
-        assert!(pmod.id().as_str() == "pgen" || pmod.id().as_str() == "igen");
+        assert!(pmod.id() == ChunkId::pgen || pmod.id() == ChunkId::igen);
 
         let size = pmod.len();
         if size % 4 != 0 || size == 0 {

--- a/soundfont-rs/src/data/hydra/instrument.rs
+++ b/soundfont-rs/src/data/hydra/instrument.rs
@@ -1,6 +1,6 @@
 use super::super::utils::Reader;
-use crate::error::ParseError;
-use riff::Chunk;
+use crate::riff::Chunk;
+use crate::{error::ParseError, riff::ChunkId};
 use std::io::{Read, Seek};
 
 #[derive(Debug, Clone)]
@@ -18,7 +18,7 @@ impl InstrumentHeader {
     }
 
     pub fn read_all<F: Read + Seek>(phdr: &Chunk, file: &mut F) -> Result<Vec<Self>, ParseError> {
-        assert_eq!(phdr.id().as_str(), "inst");
+        assert_eq!(phdr.id(), ChunkId::inst);
 
         let size = phdr.len();
         if size % 22 != 0 || size == 0 {

--- a/soundfont-rs/src/data/hydra/modulator.rs
+++ b/soundfont-rs/src/data/hydra/modulator.rs
@@ -2,7 +2,7 @@ use crate::data::generator::GeneratorType;
 use crate::error::ParseError;
 
 use super::super::utils::Reader;
-use riff::Chunk;
+use crate::riff::{Chunk, ChunkId};
 use std::convert::{TryFrom, TryInto};
 use std::io::{Read, Seek};
 
@@ -275,7 +275,7 @@ impl Modulator {
         let mut transform: u16 = reader.read_u16()?;
 
         // "The terminal record conventionally contains zero in all fields, and is always ignored."
-        // This sadly is not always true, so let's zero it out ourselfs.
+        // This sadly is not always true, so let's zero it out ourselves.
         if terminal {
             src = 0;
             dest = 0;
@@ -294,7 +294,7 @@ impl Modulator {
     }
 
     pub fn read_all<F: Read + Seek>(pmod: &Chunk, file: &mut F) -> Result<Vec<Self>, ParseError> {
-        assert!(pmod.id().as_str() == "pmod" || pmod.id().as_str() == "imod");
+        assert!(pmod.id() == ChunkId::pmod || pmod.id() == ChunkId::imod);
 
         let size = pmod.len();
         if size % 10 != 0 || size == 0 {

--- a/soundfont-rs/src/data/hydra/preset.rs
+++ b/soundfont-rs/src/data/hydra/preset.rs
@@ -1,6 +1,6 @@
 use super::super::utils::Reader;
-use crate::error::ParseError;
-use riff::Chunk;
+use crate::riff::Chunk;
+use crate::{error::ParseError, riff::ChunkId};
 
 use std::io::{Read, Seek};
 
@@ -45,7 +45,7 @@ impl PresetHeader {
     }
 
     pub fn read_all<F: Read + Seek>(phdr: &Chunk, file: &mut F) -> Result<Vec<Self>, ParseError> {
-        assert_eq!(phdr.id().as_str(), "phdr");
+        assert_eq!(phdr.id(), ChunkId::phdr);
 
         let size = phdr.len();
         if size % 38 != 0 || size == 0 {

--- a/soundfont-rs/src/data/hydra/sample.rs
+++ b/soundfont-rs/src/data/hydra/sample.rs
@@ -1,6 +1,6 @@
 use super::super::utils::Reader;
-use crate::error::ParseError;
-use riff::Chunk;
+use crate::riff::Chunk;
+use crate::{error::ParseError, riff::ChunkId};
 use std::io::{Read, Seek};
 
 #[derive(Debug, Clone)]
@@ -79,7 +79,7 @@ impl SampleHeader {
     }
 
     pub fn read_all<F: Read + Seek>(phdr: &Chunk, file: &mut F) -> Result<Vec<Self>, ParseError> {
-        assert_eq!(phdr.id().as_str(), "shdr");
+        assert_eq!(phdr.id(), ChunkId::shdr);
 
         let size = phdr.len();
         if size % 46 != 0 || size == 0 {

--- a/soundfont-rs/src/data/info.rs
+++ b/soundfont-rs/src/data/info.rs
@@ -1,6 +1,6 @@
 use super::utils::Reader;
-use crate::error::ParseError;
-use riff::Chunk;
+use crate::riff::Chunk;
+use crate::{error::ParseError, riff::ChunkId};
 
 use std::io::{Read, Seek};
 
@@ -41,8 +41,8 @@ pub struct Info {
 
 impl Info {
     pub fn read<F: Read + Seek>(info: &Chunk, file: &mut F) -> Result<Self, ParseError> {
-        assert_eq!(info.id().as_str(), "LIST");
-        assert_eq!(info.read_type(file).unwrap().as_str(), "INFO");
+        assert_eq!(info.id(), ChunkId::LIST);
+        assert_eq!(info.read_type(file)?, ChunkId::INFO);
 
         let children: Vec<_> = info.iter(file).collect();
 
@@ -64,66 +64,65 @@ impl Info {
             let ch = ch?;
             let id = ch.id();
 
-            match id.as_str() {
-                // <ifil-ck> Refers to the version of the Sound Font RIFF file
-                "ifil" => {
+            match id {
+                // Refers to the version of the Sound Font RIFF file
+                ChunkId::ifil => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     version = Some(Version {
                         major: data.read_u16()?,
                         minor: data.read_u16()?,
                     });
                 }
-                // <isng-ck> Refers to the target Sound Engine
-                "isng" => {
+                // Refers to the target Sound Engine
+                ChunkId::isng => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     sound_engine = Some(data.read_string(ch.len() as usize)?);
                 }
-                // <INAM-ck> Refers to the Sound Font Bank Name
-                "INAM" => {
+                // Refers to the Sound Font Bank Name
+                ChunkId::INAM => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     bank_name = Some(data.read_string(ch.len() as usize)?);
                 }
-
-                // [<irom-ck>] Refers to the Sound ROM Name
-                "irom" => {
+                // Refers to the Sound ROM Name
+                ChunkId::irom => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     rom_name = Some(data.read_string(ch.len() as usize)?);
                 }
-                // [<iver-ck>] Refers to the Sound ROM Version
-                "iver" => {
+                // Refers to the Sound ROM Version
+                ChunkId::iver => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     rom_version = Some(Version {
                         major: data.read_u16()?,
                         minor: data.read_u16()?,
                     });
                 }
-                // [<ICRD-ck>] Refers to the Date of Creation of the Bank
-                "ICRD" => {
+                // Refers to the Date of Creation of the Bank
+                ChunkId::ICRD => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     creation_date = Some(data.read_string(ch.len() as usize)?);
                 }
-                // [<IENG-ck>] Sound Designers and Engineers for the Bank
-                "IENG" => {
+                // Sound Designers and Engineers for the Bank
+                ChunkId::IENG => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     engineers = Some(data.read_string(ch.len() as usize)?);
                 }
-                // [<IPRD-ck>] Product for which the Bank was intended
-                "IPRD" => {
+                // Product for which the Bank was intended
+                ChunkId::IPRD => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     product = Some(data.read_string(ch.len() as usize)?);
                 }
-                // [<ICOP-ck>] Contains any Copyright message
-                "ICOP" => {
+                // Contains any Copyright message
+                ChunkId::ICOP => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     copyright = Some(data.read_string(ch.len() as usize)?);
                 }
-                // [<ICMT-ck>] Contains any Comments on the Bank
-                "ICMT" => {
+                // Contains any Comments on the Bank
+                ChunkId::ICMT => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     comments = Some(data.read_string(ch.len() as usize)?);
                 }
-                // [<ISFT-ck>] The SoundFont tools used to create and alter the bank
-                "ISFT" => {
+                // The SoundFont tools used to create and alter the bank
+                ChunkId::ISFT => {
                     let mut data = Reader::new(ch.read_contents(file).unwrap());
                     software = Some(data.read_string(ch.len() as usize)?);
                 }

--- a/soundfont-rs/src/data/sample_data.rs
+++ b/soundfont-rs/src/data/sample_data.rs
@@ -1,5 +1,5 @@
-use crate::error::ParseError;
-use riff::Chunk;
+use crate::riff::Chunk;
+use crate::{error::ParseError, riff::ChunkId};
 
 use std::io::{Read, Seek};
 
@@ -20,8 +20,8 @@ pub struct SampleData {
 
 impl SampleData {
     pub fn read<F: Read + Seek>(sdta: &Chunk, file: &mut F) -> Result<Self, ParseError> {
-        assert_eq!(sdta.id().as_str(), "LIST");
-        assert_eq!(sdta.read_type(file).unwrap().as_str(), "sdta");
+        assert_eq!(sdta.id(), ChunkId::LIST);
+        assert_eq!(sdta.read_type(file)?, ChunkId::sdta);
 
         let mut smpl = None;
         let mut sm24 = None;
@@ -30,13 +30,13 @@ impl SampleData {
             let ch = ch?;
             let id = ch.id();
 
-            match id.as_str() {
-                // [<smpl-ck>] The Digital Audio Samples for the upper 16 bits
-                "smpl" => {
+            match id {
+                // The Digital Audio Samples for the upper 16 bits
+                ChunkId::smpl => {
                     smpl = Some(ch);
                 }
-                // [<sm24-ck>] The Digital Audio Samples for the lower 8 bits
-                "sm24" => {
+                // The Digital Audio Samples for the lower 8 bits
+                ChunkId::sm24 => {
                     sm24 = Some(ch);
                 }
                 _ => {

--- a/soundfont-rs/src/error.rs
+++ b/soundfont-rs/src/error.rs
@@ -2,7 +2,7 @@ use std::array::TryFromSliceError;
 use std::io;
 use std::str::Utf8Error;
 
-use riff::Chunk;
+use crate::riff::Chunk;
 
 #[derive(Debug)]
 pub enum ParseError {

--- a/soundfont-rs/src/lib.rs
+++ b/soundfont-rs/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod data;
 pub mod error;
+mod riff;
 
 use data::{
     Bag, Generator, GeneratorAmountRange, GeneratorType, Info, InstrumentHeader, Modulator,

--- a/soundfont-rs/src/riff.rs
+++ b/soundfont-rs/src/riff.rs
@@ -1,0 +1,240 @@
+//! Utilities for reading RIFF-formatted files
+
+// (Based on `riff` MIT crate: Copyright 2018 Francesco Bertolaccini)
+
+use std::{
+    convert::TryInto,
+    fmt,
+    io::{Read, Seek, SeekFrom},
+};
+
+/// A chunk id, also known as FourCC
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
+pub struct ChunkId([u8; 4]);
+
+macro_rules! def_ids {
+    (
+        $(
+            $(#[doc = $doc:expr])?
+            $ident: ident
+        ),*
+        // trailing comma
+        $(,)?
+    ) => {
+        $(
+            $(#[doc = $doc])?
+            #[allow(non_upper_case_globals)]
+            pub const $ident: Self = Self({
+                let v = stringify!($ident).as_bytes();
+                [v[0], v[1], v[2], v[3]]
+            });
+        )*
+    };
+}
+
+impl ChunkId {
+    // 3.1 General RIFF File Structure
+    def_ids![RIFF, LIST];
+
+    // 4.1 SoundFont 2 RIFF File Format Level 0
+
+    def_ids![
+        /// RIFF form header
+        sfbk,
+    ];
+
+    // RIFF(sfbk)
+    def_ids![
+        /// Supplemental Information
+        INFO,
+        /// The Sample Binary Data
+        sdta,
+        /// The Preset, Instrument, and Sample Header data
+        pdta,
+    ];
+
+    // 4.2 SoundFont 2 RIFF File Format Level 1
+
+    // List(INFO)
+    def_ids![
+        /// Refers to the version of the Sound Font RIFF file
+        ifil,
+        /// Refers to the target Sound Engine
+        isng,
+        /// Refers to the Sound Font Bank Name
+        INAM,
+        /// Refers to the Sound ROM Name
+        irom,
+        /// Refers to the Sound ROM Version
+        iver,
+        /// Refers to the Date of Creation of the Bank
+        ICRD,
+        /// Sound Designers and Engineers for the Bank
+        IENG,
+        /// Product for which the Bank was intended
+        IPRD,
+        /// Contains any Copyright message
+        ICOP,
+        /// Contains any Comments on the Bank
+        ICMT,
+        /// The SoundFont tools used to create and alter the bank
+        ISFT,
+    ];
+
+    // List(sdta)
+    def_ids![
+        /// The Digital Audio Samples for the upper 16 bits
+        smpl,
+        /// The Digital Audio Samples for the lower 8 bits
+        sm24,
+    ];
+
+    // List(pdta)
+    def_ids![
+        /// The Preset Headers
+        phdr,
+        /// The Preset Index list
+        pbag,
+        /// The Preset Modulator list
+        pmod,
+        /// The Preset Generator list
+        pgen,
+        /// The Instrument Names and Indices
+        inst,
+        /// The Instrument Index list
+        ibag,
+        /// The Instrument Modulator list
+        imod,
+        /// The Instrument Generator list
+        igen,
+        /// The Sample Headers
+        shdr,
+    ];
+}
+
+impl fmt::Debug for ChunkId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> fmt::Result {
+        if let Ok(v) = std::str::from_utf8(&self.0) {
+            write!(f, "{v:?}")
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}
+
+/// A chunk, also known as a form
+#[derive(PartialEq, Eq, Debug)]
+pub struct Chunk {
+    pos: u64,
+    id: ChunkId,
+    len: u32,
+}
+
+/// An iterator over the children of a `Chunk`
+pub struct Iter<'a, T>
+where
+    T: Seek + Read,
+{
+    end: u64,
+    cur: u64,
+    // TODO: Make stream a `next` function argument
+    stream: &'a mut T,
+}
+
+impl<T> Iterator for Iter<'_, T>
+where
+    T: Seek + Read,
+{
+    type Item = std::io::Result<Chunk>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cur >= self.end {
+            return None;
+        }
+
+        let chunk = match Chunk::read(&mut self.stream, self.cur) {
+            Ok(chunk) => chunk,
+            Err(err) => return Some(Err(err)),
+        };
+        let len = chunk.len() as u64;
+        self.cur = self.cur + len + 8 + (len % 2);
+        Some(Ok(chunk))
+    }
+}
+
+impl Chunk {
+    /// Returns the `ChunkId` of this chunk.
+    pub fn id(&self) -> ChunkId {
+        self.id
+    }
+
+    /// Returns the number of bytes in this chunk.
+    pub fn len(&self) -> u32 {
+        self.len
+    }
+
+    /// Returns the offset of this chunk from the start of the stream.
+    pub fn offset(&self) -> u64 {
+        self.pos
+    }
+
+    /// Reads the chunk type of this chunk.
+    ///
+    /// Generally only valid for `RIFF` and `LIST` chunks.
+    pub fn read_type<T>(&self, stream: &mut T) -> std::io::Result<ChunkId>
+    where
+        T: Read + Seek,
+    {
+        stream.seek(SeekFrom::Start(self.pos + 8))?;
+
+        let mut fourcc: [u8; 4] = [0; 4];
+        stream.read_exact(&mut fourcc)?;
+
+        Ok(ChunkId(fourcc))
+    }
+
+    /// Reads a chunk from the specified position in the stream.
+    pub fn read<T>(stream: &mut T, pos: u64) -> std::io::Result<Chunk>
+    where
+        T: Read + Seek,
+    {
+        stream.seek(SeekFrom::Start(pos))?;
+
+        let mut fourcc: [u8; 4] = [0; 4];
+        stream.read_exact(&mut fourcc)?;
+
+        let mut len: [u8; 4] = [0; 4];
+        stream.read_exact(&mut len)?;
+
+        Ok(Chunk {
+            pos,
+            id: ChunkId(fourcc),
+            len: u32::from_le_bytes(len),
+        })
+    }
+
+    /// Reads the entirety of the contents of a chunk.
+    pub fn read_contents<T>(&self, stream: &mut T) -> std::io::Result<Vec<u8>>
+    where
+        T: Read + Seek,
+    {
+        stream.seek(SeekFrom::Start(self.pos + 8))?;
+
+        let mut data: Vec<u8> = vec![0; self.len.try_into().unwrap()];
+        stream.read_exact(&mut data)?;
+
+        Ok(data)
+    }
+
+    /// Returns an iterator over the children of the chunk.
+    pub fn iter<'a, T>(&self, stream: &'a mut T) -> Iter<'a, T>
+    where
+        T: Seek + Read,
+    {
+        Iter {
+            cur: self.pos + 12,
+            end: self.pos + 4 + (self.len as u64),
+            stream,
+        }
+    }
+}


### PR DESCRIPTION
It's simpler to just write the riff code in tree, this will allow us to optimize the read logic in the future even more (aka. with this code in tree, we will be able to easily eliminate all `.collect()` calls from the parser code).