### PR TITLE
soundfont-rs: Remove redundant Chunk memory allocations

### DIFF
--- a/soundfont-rs/src/data/hydra.rs
+++ b/soundfont-rs/src/data/hydra.rs
@@ -41,8 +41,6 @@ impl Hydra {
         assert_eq!(pdta.id(), ChunkId::LIST);
         assert_eq!(pdta.read_type(file)?, ChunkId::pdta);
 
-        let chunks: Vec<_> = pdta.iter(file).collect();
-
         let mut preset_headers = None;
         let mut preset_bags = None;
         let mut preset_modulators = None;
@@ -55,7 +53,8 @@ impl Hydra {
 
         let mut sample_headers = None;
 
-        for ch in chunks.into_iter() {
+        let mut iter = pdta.iter();
+        while let Some(ch) = iter.next(file) {
             let ch = ch?;
 
             match ch.id() {

--- a/soundfont-rs/src/data/info.rs
+++ b/soundfont-rs/src/data/info.rs
@@ -44,8 +44,6 @@ impl Info {
         assert_eq!(info.id(), ChunkId::LIST);
         assert_eq!(info.read_type(file)?, ChunkId::INFO);
 
-        let children: Vec<_> = info.iter(file).collect();
-
         let mut version = None;
         let mut sound_engine = None;
         let mut bank_name = None;
@@ -60,7 +58,8 @@ impl Info {
         let mut comments = None;
         let mut software = None;
 
-        for ch in children.into_iter() {
+        let mut iter = info.iter();
+        while let Some(ch) = iter.next(file) {
             let ch = ch?;
             let id = ch.id();
 

--- a/soundfont-rs/src/data/mod.rs
+++ b/soundfont-rs/src/data/mod.rs
@@ -24,13 +24,12 @@ impl SFData {
         assert_eq!(sfbk.id(), ChunkId::RIFF);
         assert_eq!(sfbk.read_type(file)?, ChunkId::sfbk);
 
-        let chunks: Vec<_> = sfbk.iter(file).collect();
-
         let mut info = None;
         let mut sample_data = None;
         let mut hydra = None;
 
-        for ch in chunks.into_iter() {
+        let mut iter = sfbk.iter();
+        while let Some(ch) = iter.next(file) {
             let ch = ch?;
             assert_eq!(ch.id(), ChunkId::LIST);
             match ch.read_type(file)? {

--- a/soundfont-rs/src/data/sample_data.rs
+++ b/soundfont-rs/src/data/sample_data.rs
@@ -26,7 +26,8 @@ impl SampleData {
         let mut smpl = None;
         let mut sm24 = None;
 
-        for ch in sdta.iter(file) {
+        let mut iter = sdta.iter();
+        while let Some(ch) = iter.next(file) {
             let ch = ch?;
             let id = ch.id();
 


### PR DESCRIPTION
Now that we have our own riff reader (#37) we can drop those allocations.

Perhaps we can drop all the io::Seek calls as well, will look into that in the future.