### PR TITLE
Fix `modenv_section` Decay/Delay typo

### DIFF
--- a/oxisynth/src/core/voice_pool/voice/mod.rs
+++ b/oxisynth/src/core/voice_pool/voice/mod.rs
@@ -295,7 +295,7 @@ impl Voice {
 
             amp: 0.0,
             modenv_count: 0,
-            modenv_section: EnvelopeStep::Decay,
+            modenv_section: EnvelopeStep::Delay,
             modenv_val: 0.0,
 
             modlfo_val: 0.0,


### PR DESCRIPTION
Noting better than 1.5 years of broken attack sound... just because of this stupid typo.
`modenv` was starting at `Decay` stage rather than `Delay` stage, causing it to skip both `Attack` and `Hold` steps :facepalm: 

Turns out that blindly accepting LSP autocompletions without reading more than 2 first letters is not the best idea...

### Before:

https://github.com/user-attachments/assets/4ad9bd67-f51c-44fb-96aa-868a035f3dd1

### After:

https://github.com/user-attachments/assets/089b2a1d-623c-48db-8158-28b2df492111

